### PR TITLE
Lightgun hack core option setup (greatgun)

### DIFF
--- a/src/mame/drivers/mazerbla.cpp
+++ b/src/mame/drivers/mazerbla.cpp
@@ -1049,7 +1049,7 @@ void mazerbla_state::greatgun(machine_config &config)
 	m_screen->set_refresh_hz(60);
 	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(2500) /* not accurate */);
 	m_screen->set_size(40*8, 32*8);
-	m_screen->set_visarea(0*8, 32*8-1, 0*8, 28*8-1);
+	m_screen->set_visarea(0*8, 32*8-1, 0*8, 32*8-1);
 	m_screen->set_screen_update(FUNC(mazerbla_state::screen_update_mazerbla));
 	m_screen->screen_vblank().set(FUNC(mazerbla_state::screen_vblank));
 

--- a/src/osd/libretro/libretro-internal/libretro.cpp
+++ b/src/osd/libretro/libretro-internal/libretro.cpp
@@ -42,6 +42,7 @@ char RPATH[512];
 static char option_mouse[50];
 static char option_lightgun[50];
 static char option_lightgun_offscreen[50];
+static char option_lightgun_hack[50];
 static char option_cheats[50];
 static char option_overclock[50];
 static char option_renderer[50];
@@ -145,6 +146,7 @@ void retro_set_environment(retro_environment_t cb)
    sprintf(option_mouse, "%s_%s", core, "mouse_enable");
    sprintf(option_lightgun, "%s_%s", core, "lightgun_mode");
    sprintf(option_lightgun_offscreen, "%s_%s", core, "lightgun_offscreen_mode");
+   sprintf(option_lightgun_hack, "%s_%s", core, "lightgun_hack");
    sprintf(option_cheats, "%s_%s", core, "cheats_enable");
    sprintf(option_overclock, "%s_%s", core, "cpu_overclock");
    sprintf(option_renderer,"%s_%s",core,"alternate_renderer");
@@ -173,6 +175,7 @@ void retro_set_environment(retro_environment_t cb)
     { option_mouse, "Enable in-game mouse; disabled|enabled" },
     { option_lightgun, "Lightgun mode; none|touchscreen|lightgun" },
     { option_lightgun_offscreen, "Lightgun offscreen position; free|fixed (top left)|fixed (bottom right)" },
+	{ option_lightgun_hack, "Lightgun aim hack; none|greatgun" },
     { option_buttons_profiles, "Profile Buttons according to games (Restart); enabled|disabled" },
     { option_throttle, "Enable throttle; disabled|enabled" },
     { option_cheats, "Enable cheats; disabled|enabled" },
@@ -265,6 +268,17 @@ static void check_variables(void)
          lightgun_offscreen_mode = 1;
 	  else
          lightgun_offscreen_mode = 2;
+   }
+	
+   var.key   = option_lightgun_hack;
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "none"))
+         lightgun_hack = 0;
+      if (!strcmp(var.value, "greatgun"))
+         lightgun_hack = 1;
    }
 
    var.key   = option_buttons_profiles;

--- a/src/osd/libretro/libretro-internal/libretro_shared.h
+++ b/src/osd/libretro/libretro-internal/libretro_shared.h
@@ -64,6 +64,7 @@ extern bool hide_gameinfo;
 extern bool mouse_enable;
 extern int  lightgun_mode;
 extern int  lightgun_offscreen_mode;
+extern int  lightgun_hack;
 extern bool cheats_enable;
 extern bool alternate_renderer;
 extern bool boot_to_osd_enable;

--- a/src/osd/libretro/libretro-internal/retro_init.cpp
+++ b/src/osd/libretro/libretro-internal/retro_init.cpp
@@ -49,6 +49,7 @@ bool nobuffer_enable = false;
 bool mouse_enable = false;
 int  lightgun_mode = RETRO_SETTING_LIGHTGUN_MODE_DISABLED;
 int  lightgun_offscreen_mode = 1;
+int  lightgun_hack = 0;
 bool cheats_enable = false;
 bool alternate_renderer = false;
 bool boot_to_osd_enable = false;

--- a/src/osd/modules/input/input_retro.cpp
+++ b/src/osd/modules/input/input_retro.cpp
@@ -770,8 +770,17 @@ void retro_osd_interface::process_lightgun_state(running_machine &machine)
             lightgunstate[j].lightgunBUT[1] = 0x80;
          }
       }
-      lightgunX[j] = gun_x_raw[j] * 2;
-      lightgunY[j] = gun_y_raw[j] * 2;
+
+      if (lightgun_hack == 1)
+	  {
+		  lightgunX[j] = gun_x_raw[j] * 2;
+          lightgunY[j] = gun_y_raw[j] * 2 + 12650;
+	  }
+	  else
+	  {
+		  lightgunX[j] = gun_x_raw[j] * 2;
+          lightgunY[j] = gun_y_raw[j] * 2;
+	  }
 	   
       //Place the cursor at a corner of the screen designated by "Lightgun offscreen position" when the cursor touches a min/max value
       if (input_state_cb( j, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ))


### PR DESCRIPTION
Add a core option to activate game-specific alignment hacks. This particular one gives line-of-sight alignment for greatgun.